### PR TITLE
Argument fix for single_connection method

### DIFF
--- a/oneshot.py
+++ b/oneshot.py
@@ -1218,7 +1218,7 @@ if __name__ == '__main__':
                     if args.bruteforce:
                         companion.smart_bruteforce(args.bssid, args.pin, args.delay)
                     else:
-                        companion.single_connection(args.bssid, args.pin, args.pixie_dust,
+                        companion.single_connection(args.bssid, args.pin, args.pixie_dust, args.pbc,
                                                     args.show_pixie_cmd, args.pixie_force)
             if not args.loop:
                 break


### PR DESCRIPTION
Check the 4th parameter of single_connection method's definition, it's pbc_mode, so we need to pass args.pbc as 4th argument here.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the argument order in the call to the single_connection method by passing args.pbc as the fourth argument instead of args.pixie_dust.

Bug Fixes:
- Fix the argument passed to the single_connection method by replacing the incorrect third argument with the correct fourth argument, args.pbc.

<!-- Generated by sourcery-ai[bot]: end summary -->